### PR TITLE
feat: add Playwright e2e testing infrastructure (#65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ TELEGRAM_BOT_TOKEN=xxxxx:xxxxx
 # Next.js Environment
 NODE_ENV=development
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# E2E Testing (Playwright)
+E2E_TEST_EMAIL=bob@matsuoka.com

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ kuzu-memories/
 benchmark-results/
 *.benchmark.json
 *.benchmark.md
+
+# Playwright E2E tests
+tests/e2e/playwright/.auth/
+playwright-report/
+test-results/
+.playwright/

--- a/PLAYWRIGHT_SETUP.md
+++ b/PLAYWRIGHT_SETUP.md
@@ -1,0 +1,84 @@
+# Playwright E2E Testing - Quick Setup Guide
+
+## First-Time Setup
+
+### 1. Install Playwright browsers
+```bash
+npx playwright install chromium
+```
+
+### 2. Add environment variable
+Add to your `.env.local`:
+```bash
+E2E_TEST_EMAIL=bob@matsuoka.com
+```
+
+### 3. First authentication (ONE TIME)
+You need to authenticate manually the first time:
+
+```bash
+# Start dev server (if not already running)
+npm run dev
+
+# In another terminal, run setup with browser UI visible
+npx playwright test --headed --project=setup
+```
+
+**Complete the Google OAuth login** in the browser window that opens. The authentication state will be saved automatically.
+
+## Running Tests
+
+After initial setup, run tests normally (headless):
+
+```bash
+# Run all E2E tests
+npm run test:e2e:playwright
+
+# Run with interactive UI
+npm run test:e2e:playwright:ui
+
+# Run in debug mode
+npm run test:e2e:playwright:debug
+
+# Run with browser visible
+npm run test:e2e:playwright:headed
+
+# Run specific test file
+npx playwright test specs/dashboard.spec.ts
+```
+
+## Troubleshooting
+
+### "Auth state not found"
+Delete old auth and re-authenticate:
+```bash
+rm -f tests/e2e/playwright/.auth/user.json
+npx playwright test --headed --project=setup
+```
+
+### Dev Server Not Starting
+If tests fail to connect:
+```bash
+# Ensure dev server is running
+npm run dev
+
+# Or run tests without starting server
+npx playwright test --no-server
+```
+
+## Test Structure
+
+```
+tests/e2e/playwright/
+├── .auth/              # Auth state (gitignored)
+├── fixtures/           # Custom test fixtures
+├── specs/              # Test files
+│   ├── auth.spec.ts
+│   ├── dashboard.spec.ts
+│   └── navigation.spec.ts
+└── auth.setup.ts       # Auth setup
+```
+
+## More Information
+
+See full documentation: [tests/e2e/playwright/README.md](tests/e2e/playwright/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "zod": "^4.3.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
@@ -4087,6 +4088,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -10811,6 +10828,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:e2e": "vitest run tests/e2e",
+    "test:e2e:playwright": "playwright test",
+    "test:e2e:playwright:ui": "playwright test --ui",
+    "test:e2e:playwright:debug": "playwright test --debug",
+    "test:e2e:playwright:headed": "playwright test --headed",
     "test:proxy": "tsx tests/proxy/run-proxy-tests.ts",
     "test:cov": "vitest run --coverage",
     "test:ui": "vitest --ui",
@@ -68,6 +72,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@typescript-eslint/eslint-plugin": "^8.51.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E Test Configuration
+ *
+ * Headless browser testing for Next.js application with Better Auth.
+ *
+ * Key Features:
+ * - Runs in headless mode by default
+ * - Uses auth state persistence for authenticated tests
+ * - Configured for local development (localhost:3002)
+ * - Single browser (Chromium) for simplicity
+ */
+export default defineConfig({
+  // Test directory
+  testDir: './tests/e2e/playwright',
+
+  // Maximum time one test can run
+  timeout: 30 * 1000,
+
+  // Test execution settings
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter configuration
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['list'],
+  ],
+
+  // Shared settings for all tests
+  use: {
+    // Base URL for navigation
+    baseURL: 'http://localhost:3300',
+
+    // Capture screenshot on failure
+    screenshot: 'only-on-failure',
+
+    // Capture video on first retry
+    video: 'retain-on-failure',
+
+    // Trace on first retry
+    trace: 'on-first-retry',
+
+    // Browser context options
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+  },
+
+  // Projects (browsers to test)
+  projects: [
+    // Setup project - runs first to authenticate
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+
+    // Chromium tests - depend on setup
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Use saved auth state from setup
+        storageState: 'tests/e2e/playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+
+  // Web server configuration
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3300',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/e2e/playwright/README.md
+++ b/tests/e2e/playwright/README.md
@@ -1,0 +1,271 @@
+# Playwright E2E Tests
+
+Headless end-to-end testing for the Next.js application using Playwright.
+
+## Overview
+
+This test suite provides:
+- **Authenticated testing** with Google OAuth via Better Auth
+- **Headless execution** by default (no browser UI)
+- **Auth state persistence** to avoid repeated logins
+- **Read-only tests** that are safe and idempotent
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+### 2. Setup Environment
+
+Add to your `.env.local`:
+
+```bash
+E2E_TEST_EMAIL=bob@matsuoka.com
+```
+
+### 3. First-Time Authentication
+
+**IMPORTANT**: The first time you run tests, you need to authenticate manually:
+
+```bash
+# Run setup in headed mode (shows browser)
+npx playwright test --headed --project=setup
+
+# Complete Google OAuth login in the browser window
+# Auth state will be saved to .auth/user.json
+```
+
+### 4. Run Tests
+
+After initial setup, run tests in headless mode:
+
+```bash
+# Run all tests
+npm run test:e2e:playwright
+
+# Run with UI mode (interactive)
+npm run test:e2e:playwright:ui
+
+# Run in debug mode
+npm run test:e2e:playwright:debug
+
+# Run specific test file
+npx playwright test specs/dashboard.spec.ts
+```
+
+## Directory Structure
+
+```
+tests/e2e/playwright/
+├── .auth/                    # Auth state (gitignored)
+│   └── user.json            # Saved authentication state
+├── fixtures/
+│   └── auth.ts              # Custom test fixtures
+├── specs/
+│   ├── auth.spec.ts         # Authentication tests
+│   ├── dashboard.spec.ts    # Dashboard functionality tests
+│   └── navigation.spec.ts   # Navigation and routing tests
+├── auth.setup.ts            # Auth setup (runs before tests)
+└── README.md                # This file
+```
+
+## Test Files
+
+### `auth.setup.ts`
+Runs once before all tests to authenticate and save session state.
+
+### `specs/auth.spec.ts`
+Verifies authentication state:
+- User is authenticated
+- User information is displayed
+- Session cookies are valid
+- Login button is hidden
+
+### `specs/dashboard.spec.ts`
+Tests dashboard functionality:
+- Page loads correctly
+- Main sections are visible
+- No console errors
+- Responsive design
+- Data loads without errors
+
+### `specs/navigation.spec.ts`
+Tests application navigation:
+- Route navigation works
+- Browser back/forward buttons work
+- 404 pages handled gracefully
+- Authentication persists across navigation
+- Keyboard navigation is accessible
+
+## Configuration
+
+### Playwright Config (`playwright.config.ts`)
+
+Key settings:
+- **Base URL**: `http://localhost:3300`
+- **Browser**: Chromium only (Desktop Chrome)
+- **Timeout**: 30 seconds per test
+- **Headless**: Enabled by default
+- **Screenshots**: Captured on failure
+- **Video**: Retained on failure
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `E2E_TEST_EMAIL` | Test user email | `bob@matsuoka.com` |
+
+## Writing Tests
+
+### Basic Test Structure
+
+```typescript
+import { test, expect } from '../fixtures/auth';
+
+test.describe('My Feature', () => {
+  test('should do something', async ({ page }) => {
+    await page.goto('/my-page');
+    await expect(page.getByRole('heading')).toBeVisible();
+  });
+});
+```
+
+### Best Practices
+
+1. **Use semantic selectors**: Prefer `getByRole`, `getByText`, `getByTestId`
+2. **Write idempotent tests**: Tests should not modify data
+3. **Wait for elements**: Use `expect().toBeVisible()` instead of arbitrary waits
+4. **Handle async operations**: Use `waitForLoadState('networkidle')`
+5. **Clean up console errors**: Listen for and assert no unexpected errors
+
+### Test Data Attributes
+
+Add `data-testid` attributes to make tests more reliable:
+
+```tsx
+<div data-testid="user-menu">
+  {user.name}
+</div>
+```
+
+```typescript
+// In tests
+const userMenu = page.getByTestId('user-menu');
+await expect(userMenu).toBeVisible();
+```
+
+## Debugging
+
+### Run Tests with UI
+
+```bash
+npm run test:e2e:playwright:ui
+```
+
+Shows interactive UI to:
+- Step through tests
+- Inspect page state
+- View network requests
+- See screenshots/videos
+
+### Debug Mode
+
+```bash
+npm run test:e2e:playwright:debug
+```
+
+Opens Playwright Inspector to:
+- Set breakpoints
+- Step through code
+- Inspect selectors
+- View console logs
+
+### View Test Report
+
+```bash
+npx playwright show-report
+```
+
+Opens HTML report with:
+- Test results
+- Screenshots
+- Videos
+- Traces
+
+## Troubleshooting
+
+### Auth Setup Fails
+
+**Problem**: OAuth flow doesn't complete
+
+**Solution**:
+```bash
+# Delete old auth state
+rm -rf tests/e2e/playwright/.auth/user.json
+
+# Re-run setup in headed mode
+npx playwright test --headed --project=setup
+```
+
+### Tests Fail with "Element not found"
+
+**Problem**: Selectors don't match your UI
+
+**Solution**: Update selectors in test files to match your actual UI elements.
+
+### Server Not Starting
+
+**Problem**: Dev server doesn't start automatically
+
+**Solution**: Start server manually in another terminal:
+```bash
+npm run dev
+```
+
+Then run tests with:
+```bash
+npx playwright test --no-server
+```
+
+### Viewport Issues
+
+**Problem**: Elements not visible in headless mode
+
+**Solution**: Tests use 1280x720 viewport by default. Adjust in `playwright.config.ts`:
+```typescript
+use: {
+  viewport: { width: 1920, height: 1080 },
+}
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+- name: Install Playwright
+  run: npx playwright install --with-deps chromium
+
+- name: Run E2E tests
+  run: npm run test:e2e:playwright
+  env:
+    E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+
+- name: Upload test results
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: playwright-report
+    path: playwright-report/
+```
+
+## Resources
+
+- [Playwright Documentation](https://playwright.dev)
+- [Best Practices](https://playwright.dev/docs/best-practices)
+- [Debugging Guide](https://playwright.dev/docs/debug)
+- [API Reference](https://playwright.dev/docs/api/class-test)

--- a/tests/e2e/playwright/auth.setup.ts
+++ b/tests/e2e/playwright/auth.setup.ts
@@ -1,0 +1,75 @@
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+
+/**
+ * Authentication Setup for Playwright Tests
+ *
+ * This setup script runs ONCE before all tests to authenticate with Google OAuth
+ * and save the authenticated state to a file. Subsequent tests reuse this state.
+ *
+ * IMPORTANT: First-time setup requires manual authentication:
+ * 1. Run with headed mode: npx playwright test --headed --project=setup
+ * 2. Complete Google OAuth login manually
+ * 3. The auth state will be saved to .auth/user.json
+ * 4. Subsequent runs will reuse this state automatically
+ *
+ * Environment Variables:
+ * - E2E_TEST_EMAIL: Test user email (default: bob@matsuoka.com)
+ */
+
+const authFile = path.join(__dirname, '.auth/user.json');
+
+setup('authenticate with Google OAuth', async ({ page }) => {
+  const testEmail = process.env.E2E_TEST_EMAIL || 'bob@matsuoka.com';
+
+  console.log(`🔐 Authenticating as ${testEmail}...`);
+
+  // Navigate to the application
+  await page.goto('http://localhost:3300');
+
+  // Check if already authenticated by looking for common authenticated UI elements
+  // Adjust these selectors based on your app's authenticated state
+  const isAuthenticated = await page
+    .getByText(/dashboard|profile|logout/i)
+    .first()
+    .isVisible()
+    .catch(() => false);
+
+  if (isAuthenticated) {
+    console.log('✅ Already authenticated, saving state...');
+    await page.context().storageState({ path: authFile });
+    return;
+  }
+
+  // Not authenticated - need to login
+  console.log('🚀 Starting Google OAuth flow...');
+
+  // Click on "Sign in with Google" button
+  // Adjust this selector based on your actual sign-in button
+  const signInButton = page.getByRole('button', { name: /sign in with google/i });
+  await signInButton.click();
+
+  // Wait for Google OAuth popup or redirect
+  // This will require manual interaction in headed mode for first-time setup
+  console.log('⏳ Waiting for OAuth flow to complete...');
+  console.log('ℹ️  If this is your first time, complete the Google login manually');
+
+  // Wait for navigation back to the app after OAuth
+  await page.waitForURL('http://localhost:3300/**', {
+    timeout: 120000, // 2 minutes for manual OAuth completion
+  });
+
+  // Wait for authenticated state (adjust selector to your app)
+  await page.waitForSelector('[data-testid="user-menu"], [data-testid="dashboard"]', {
+    timeout: 10000,
+  });
+
+  console.log('✅ Authentication successful!');
+
+  // Save the authenticated state
+  await page.context().storageState({ path: authFile });
+  console.log(`💾 Auth state saved to ${authFile}`);
+
+  // Verify we're logged in
+  expect(page.url()).toContain('localhost:3300');
+});

--- a/tests/e2e/playwright/fixtures/auth.ts
+++ b/tests/e2e/playwright/fixtures/auth.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test';
+
+/**
+ * Custom Playwright fixtures for authenticated tests
+ *
+ * Extends base Playwright test with custom fixtures and utilities.
+ * The auth state is automatically loaded via playwright.config.ts storageState.
+ */
+
+type AuthFixtures = {
+  // Add custom fixtures here if needed
+  // For example: authenticatedPage, adminUser, etc.
+};
+
+/**
+ * Authenticated test fixture
+ *
+ * Usage:
+ *   import { test, expect } from '../fixtures/auth';
+ *
+ *   test('my authenticated test', async ({ page }) => {
+ *     // page is already authenticated
+ *     await page.goto('/dashboard');
+ *   });
+ */
+export const test = base.extend<AuthFixtures>({
+  // Custom fixtures can be added here
+  // Example:
+  // authenticatedPage: async ({ page }, use) => {
+  //   // Custom page setup
+  //   await use(page);
+  // },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e/playwright/specs/auth.spec.ts
+++ b/tests/e2e/playwright/specs/auth.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../fixtures/auth';
+
+/**
+ * Authentication Flow Tests
+ *
+ * Read-only tests to verify authentication state and user session.
+ * Uses pre-authenticated state from auth.setup.ts.
+ */
+
+test.describe('Authentication', () => {
+  test('should be authenticated', async ({ page }) => {
+    await page.goto('/');
+
+    // Verify we're logged in by checking for authenticated UI elements
+    // Adjust selectors based on your app's UI
+    const isAuthenticated =
+      (await page.getByTestId('user-menu').isVisible().catch(() => false)) ||
+      (await page.getByRole('button', { name: /logout|sign out/i }).isVisible().catch(() => false));
+
+    expect(isAuthenticated).toBe(true);
+  });
+
+  test('should display user information', async ({ page }) => {
+    await page.goto('/');
+
+    // Check for user email or name in the UI
+    // Adjust selector based on where user info is displayed
+    const userInfo = page.getByTestId('user-info').or(page.getByTestId('user-email'));
+
+    // Should contain the test user email
+    const testEmail = process.env.E2E_TEST_EMAIL || 'bob@matsuoka.com';
+    await expect(userInfo.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should have valid session cookies', async ({ context }) => {
+    const cookies = await context.cookies();
+
+    // Verify Better Auth session cookie exists
+    // Adjust cookie name based on Better Auth configuration
+    const sessionCookie = cookies.find(
+      (cookie) =>
+        cookie.name.includes('session') ||
+        cookie.name.includes('better-auth') ||
+        cookie.name.includes('auth')
+    );
+
+    expect(sessionCookie).toBeDefined();
+    expect(sessionCookie?.value).toBeTruthy();
+  });
+
+  test('should not show login button when authenticated', async ({ page }) => {
+    await page.goto('/');
+
+    // Login button should not be visible when authenticated
+    const loginButton = page.getByRole('button', { name: /sign in|login/i });
+    await expect(loginButton).not.toBeVisible();
+  });
+});

--- a/tests/e2e/playwright/specs/dashboard.spec.ts
+++ b/tests/e2e/playwright/specs/dashboard.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../fixtures/auth';
+
+/**
+ * Dashboard Tests
+ *
+ * Read-only tests to verify dashboard functionality and data display.
+ * Tests are idempotent and do not mutate any data.
+ */
+
+test.describe('Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to dashboard before each test
+    await page.goto('/dashboard');
+  });
+
+  test('should load dashboard page', async ({ page }) => {
+    // Verify dashboard page loads
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page).toHaveTitle(/dashboard/i);
+  });
+
+  test('should display main dashboard sections', async ({ page }) => {
+    // Check for common dashboard elements
+    // Adjust selectors based on your actual dashboard UI
+    const mainContent = page.getByRole('main').or(page.getByTestId('dashboard-content'));
+    await expect(mainContent).toBeVisible();
+
+    // Verify page heading
+    const heading = page.getByRole('heading', { name: /dashboard/i, level: 1 });
+    await expect(heading.first()).toBeVisible();
+  });
+
+  test('should not show any console errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+
+    // Listen for console errors
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Navigate and wait for page to load
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Filter out known/acceptable errors (adjust as needed)
+    const unexpectedErrors = consoleErrors.filter(
+      (error) =>
+        !error.includes('favicon') && // Ignore favicon errors
+        !error.includes('sourcemap') // Ignore sourcemap warnings
+    );
+
+    expect(unexpectedErrors).toHaveLength(0);
+  });
+
+  test('should be responsive', async ({ page }) => {
+    // Test mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/dashboard');
+    await expect(page.getByRole('main')).toBeVisible();
+
+    // Test tablet viewport
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await expect(page.getByRole('main')).toBeVisible();
+
+    // Test desktop viewport
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+
+  test('should have working navigation menu', async ({ page }) => {
+    // Check for navigation menu
+    const nav = page.getByRole('navigation').or(page.getByTestId('nav-menu'));
+    await expect(nav.first()).toBeVisible();
+
+    // Verify common navigation items exist
+    // Adjust based on your actual navigation structure
+    const navItems = page.getByRole('navigation').getByRole('link');
+    const count = await navItems.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('should load data without errors', async ({ page }) => {
+    // Wait for any data fetching to complete
+    await page.waitForLoadState('networkidle');
+
+    // Check for loading indicators (should be gone)
+    const loader = page.getByTestId('loading').or(page.getByText(/loading/i));
+    await expect(loader).not.toBeVisible();
+
+    // Verify no error messages
+    const errorMessage = page.getByTestId('error-message').or(page.getByText(/error|failed/i));
+    await expect(errorMessage).not.toBeVisible();
+  });
+});

--- a/tests/e2e/playwright/specs/navigation.spec.ts
+++ b/tests/e2e/playwright/specs/navigation.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '../fixtures/auth';
+
+/**
+ * Navigation Tests
+ *
+ * Read-only tests to verify application navigation and routing.
+ * Tests verify that routes are accessible and render correctly.
+ */
+
+test.describe('Navigation', () => {
+  test('should navigate to home page', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\//);
+
+    // Verify home page loads
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+
+  test('should navigate between pages using links', async ({ page }) => {
+    await page.goto('/');
+
+    // Find and click a navigation link (adjust selector based on your nav)
+    const navLinks = page.getByRole('navigation').getByRole('link');
+    const firstLink = navLinks.first();
+
+    if ((await firstLink.count()) > 0) {
+      const linkText = await firstLink.textContent();
+      await firstLink.click();
+
+      // Wait for navigation to complete
+      await page.waitForLoadState('networkidle');
+
+      // Verify navigation occurred
+      await expect(page.getByRole('main')).toBeVisible();
+    }
+  });
+
+  test('should handle browser back/forward navigation', async ({ page }) => {
+    // Navigate to home
+    await page.goto('/');
+    const homeUrl = page.url();
+
+    // Navigate to dashboard
+    await page.goto('/dashboard');
+    const dashboardUrl = page.url();
+
+    // Go back
+    await page.goBack();
+    await expect(page).toHaveURL(homeUrl);
+
+    // Go forward
+    await page.goForward();
+    await expect(page).toHaveURL(dashboardUrl);
+  });
+
+  test('should handle 404 pages gracefully', async ({ page }) => {
+    // Navigate to non-existent route
+    await page.goto('/this-page-does-not-exist');
+
+    // Should show 404 page or redirect
+    const is404 =
+      (await page.getByText(/404|not found/i).isVisible().catch(() => false)) ||
+      (await page.getByRole('heading', { name: /404|not found/i }).isVisible().catch(() => false));
+
+    // Either shows 404 or redirects to valid page
+    expect(is404 || page.url().includes('/')).toBeTruthy();
+  });
+
+  test('should maintain authentication across navigation', async ({ page }) => {
+    // Start at home
+    await page.goto('/');
+
+    // Navigate to multiple pages
+    const routes = ['/dashboard', '/', '/dashboard'];
+
+    for (const route of routes) {
+      await page.goto(route);
+
+      // Verify still authenticated (adjust selector based on your UI)
+      const isAuthenticated =
+        (await page.getByTestId('user-menu').isVisible().catch(() => false)) ||
+        (await page
+          .getByRole('button', { name: /logout|sign out/i })
+          .isVisible()
+          .catch(() => false));
+
+      expect(isAuthenticated).toBe(true);
+    }
+  });
+
+  test('should have accessible navigation', async ({ page }) => {
+    await page.goto('/');
+
+    // Check that navigation is keyboard accessible
+    const nav = page.getByRole('navigation').first();
+    await expect(nav).toBeVisible();
+
+    // Verify navigation has proper ARIA labels
+    const navLabel = await nav.getAttribute('aria-label');
+    expect(navLabel).toBeTruthy();
+  });
+
+  test('should preserve state during navigation', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // Get initial state (e.g., URL parameters, scroll position)
+    const initialUrl = page.url();
+
+    // Navigate away and back
+    await page.goto('/');
+    await page.goto(initialUrl);
+
+    // Verify we're back at the same page
+    await expect(page).toHaveURL(initialUrl);
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Sets up headless end-to-end testing with Playwright using authenticated user session (bob@matsuoka.com) for read-only testing.

### Infrastructure Added
- **playwright.config.ts** - Headless chromium config with auth persistence
- **tests/e2e/playwright/** - Complete test directory structure
- **Auth state storage** in `.auth/` (gitignored for security)

### Test Suite (All Read-Only)
| File | Tests |
|------|-------|
| `auth.setup.ts` | Google OAuth login with state persistence |
| `auth.spec.ts` | Authentication verification |
| `dashboard.spec.ts` | Dashboard loading and content |
| `navigation.spec.ts` | Routing and browser navigation |

### Configuration
- `E2E_TEST_EMAIL` env var for test user
- Auto-starts dev server if not running
- Screenshots/video on test failure

### NPM Scripts
```bash
npm run test:e2e:playwright       # Headless tests
npm run test:e2e:playwright:ui    # Interactive UI mode
npm run test:e2e:playwright:debug # Debug mode
```

### First-Time Setup
```bash
# 1. Add to .env.local
E2E_TEST_EMAIL=bob@matsuoka.com

# 2. First-time auth (opens browser)
npx playwright test --headed --project=setup

# 3. Run tests
npm run test:e2e:playwright
```

## Files Changed (12 files, ~900 lines)
- `playwright.config.ts` - Main config
- `tests/e2e/playwright/` - Test suite
- `.env.example` - Added E2E_TEST_EMAIL
- `.gitignore` - Added Playwright artifacts
- `package.json` - Added scripts and @playwright/test

## Test Plan
- [x] Playwright installed and configured
- [x] Auth setup with state persistence
- [x] Read-only test specs created
- [x] Documentation complete
- [ ] Manual first-time auth (requires browser)

Resolves #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)